### PR TITLE
fix: explicit migration startup filter

### DIFF
--- a/Mongo.Migration/Startup/DotNetCore/MongoMigrationExtensions.cs
+++ b/Mongo.Migration/Startup/DotNetCore/MongoMigrationExtensions.cs
@@ -14,14 +14,14 @@ namespace Mongo.Migration.Startup.DotNetCore
 {
     public static class MongoMigrationExtensions
     {
-        public static void AddMigration(
-            this IServiceCollection services,
-            IMongoMigrationSettings settings = null)
+        public static void AddMigration(this IServiceCollection services, IMongoMigrationSettings settings = null)
         {
             RegisterDefaults(services, settings ?? new MongoMigrationSettings());
 
             services.AddScoped<IMigrationService, MigrationService>();
         }
+
+        public static void AddMigrationStartupFilter(this IServiceCollection services) => services.AddTransient<IStartupFilter, MongoMigrationStartupFilter>();
 
         private static void RegisterDefaults(IServiceCollection services, IMongoMigrationSettings settings)
         {
@@ -48,7 +48,6 @@ namespace Mongo.Migration.Startup.DotNetCore
             services.AddTransient<IMigrationInterceptorProvider, MigrationInterceptorProvider>();
 
             services.AddTransient<IMongoMigration, MongoMigration>();
-            services.AddTransient<IStartupFilter, MongoMigrationStartupFilter>();
         }
     }
 }


### PR DESCRIPTION
## Summary of changes[^practices]

While we do not currently use this feature and component tests just run forever, explicitly register the startup filter

Related Work Item: [AB#36716](https://dev.azure.com/SWEngineering/8e6bc3ba-ba84-4595-8560-f51b3fe8e2b5/_workitems/edit/36716)

## Dependencies

None

## Dependents[^deps]

Persistence.Mongo

### Checks

````text
Remove checks which do not apply, since the list serves as task progress display in the PR's overview.
````

- [x] I have labeled the PR correctly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tagged a commit in this PR with correct version
- [ ] I have maximized the division of this story and could not make multiple smaller PRs
- [ ] I have used stable versions for every package in this PR
- [ ] The changelogs are writen in the story

![image](https://app.office-protect.com/assets/office-protect-logo-white.png)

[^practices]: https://wiki.sherweb.com/display/TUR/Meilleures+pratiques+pour+la+revue+de+pull+requests
[^deps]: https://github.com/sherweb/OfficeProtect.Utils/blob/master/dependencies/README.md
[^versioning]: https://github.com/sherweb/OfficeProtect.Application/blob/master/docs/software/application-versioning.md
