### PR TITLE
fix: reduce log level when no migrations are found

### DIFF
--- a/Mongo.Migration/Migrations/Locators/MigrationLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/MigrationLocator.cs
@@ -34,7 +34,7 @@ namespace Mongo.Migration.Migrations.Locators
 
                 if (this._migrations.NullOrEmpty())
                 {
-                    this._logger.Info(new NoMigrationsFoundException());
+                    this._logger.Debug(new NoMigrationsFoundException());
                 }
 
                 return this._migrations;


### PR DESCRIPTION
## Summary of changes[^practices]

Reducing the log level to debug when no migrations are found, since this is a valid use case.

Related Work Item: AB#49739

## Dependencies

None

## Dependents[^deps]

None

### Checks

- [x] I have labeled the PR correctly
- [x] I have set the PR title with the proper versioning[^versioning] prefix (will help for the merge commit message)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maximized the division of this story and could not make multiple smaller PRs
- [x] I have used stable versions for every package in this PR (if not dependending on an unclosed PR)
- [ ] The changelog is written in the story

![image](https://app.office-protect.com/assets/office-protect-logo-white.png)

[^practices]: https://wiki.sherweb.com/display/TUR/Meilleures+pratiques+pour+la+revue+de+pull+requests
[^deps]: https://github.com/sherweb/OfficeProtect.Utils/blob/master/dependencies/README.md
[^versioning]: https://github.com/sherweb/OfficeProtect.Application/blob/master/docs/software/application-versioning.md
