### PR TITLE
feat: dotnet8 migration AB#66831

### DIFF
--- a/.pipelines/azure-pipelines-pr.yaml
+++ b/.pipelines/azure-pipelines-pr.yaml
@@ -16,7 +16,7 @@ parameters:
     default: "none"
   - name: dotNetSdkVersion
     type: string
-    default: '6.x'
+    default: '8.x'
   - name: gitRepoName
     type: string
     default: "Mongo.Migration"

--- a/.pipelines/azure-pipelines.yaml
+++ b/.pipelines/azure-pipelines.yaml
@@ -19,7 +19,7 @@ parameters:
     default: "none"
   - name: dotNetSdkVersion
     type: string
-    default: '6.x'
+    default: '8.x'
   - name: gitRepoName
     type: string
     default: "Mongo.Migration"

--- a/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
+++ b/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
@@ -15,11 +15,11 @@
     <Compile Remove="..\Mongo.Migration.Test\Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
+++ b/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
-	  <TargetFrameworks>net6.0</TargetFrameworks>
-	  <Platforms>x64</Platforms>
+	  <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Mongo.Migration.Test\**\*.cs" />

--- a/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
+++ b/Mongo.Migration.Test.Core/Mongo.Migration.Test.Core.csproj
@@ -16,11 +16,11 @@
     <Compile Remove="..\Mongo.Migration.Test\Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -29,9 +29,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="Mongo2Go" Version="3.1.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/Mongo.Migration.sln
+++ b/Mongo.Migration.sln
@@ -20,8 +20,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8DFFD615-1E1A-4BED-8A96-CAF4C3637E81}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{8DFFD615-1E1A-4BED-8A96-CAF4C3637E81}.Debug|Any CPU.Build.0 = Debug|x64
+		{8DFFD615-1E1A-4BED-8A96-CAF4C3637E81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DFFD615-1E1A-4BED-8A96-CAF4C3637E81}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DFFD615-1E1A-4BED-8A96-CAF4C3637E81}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DFFD615-1E1A-4BED-8A96-CAF4C3637E81}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1EEC8464-61D1-4FA3-97D4-21A35A45F3FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Mongo.Migration/Mongo.Migration.csproj
+++ b/Mongo.Migration/Mongo.Migration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Platforms>x64</Platforms>
+    <TargetFramework>net8.0</TargetFramework>
     <Company>Sherweb</Company>
     <Authors>Sherweb</Authors>
     <Product>Office Protect</Product>
@@ -25,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="LightInject" Version="6.6.4" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="6.0.27" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Mongo.Migration/Mongo.Migration.csproj
+++ b/Mongo.Migration/Mongo.Migration.csproj
@@ -24,9 +24,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="LightInject" Version="6.6.4" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="MinVer" Version="4.3.0">
+    <PackageReference Include="MinVer" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Mongo.Migration/Mongo.Migration.csproj
+++ b/Mongo.Migration/Mongo.Migration.csproj
@@ -25,13 +25,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="LightInject" Version="6.6.4" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="6.0.25" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="6.0.27" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
     <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <None Include="op-icon.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
BREAKING CHANGES: yes, there will be

## Summary of changes[^practices]

dotnet8 migration

Related Work Item: [AB#66831](https://dev.azure.com/SWEngineering/8e6bc3ba-ba84-4595-8560-f51b3fe8e2b5/_workitems/edit/66831)

### Impact analysis[^usecases]

The dotnet framework is updated. The impact is everywhere.

## Dependencies

None

## Dependents[^deps]

All, since part of this is part of the overall initiative.

### Checks

- [x] I have labeled the PR type: `bug`, `refactoring`, `feature`, `breaking change`
- [x] I have labeled the PR risk: `lo-risk`, `med-risk`, `hi-risk`
- [x] I have labeled the PR visibility: `client-facing`
- [x] I have set the PR title with the proper versioning[^versioning] prefix (will help for the merge commit message)
- [x] I have set the PR title with the proper Azure Devops work item suffix (AB#xxxxx)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maximized the division of this story and could not make multiple smaller PRs
- [x] I have used stable versions for every package in this PR (if not dependending on an unclosed PR)
- [ ] The changelog is written in the story

![image](https://app.office-protect.com/assets/office-protect-logo-white.png)

[^practices]: <https://wiki.sherweb.com/display/TUR/Meilleures+pratiques+pour+la+revue+de+pull+requests>
[^deps]: <https://github.com/sherweb/OfficeProtect.Utils/blob/master/dependencies/README.md>
[^versioning]: <https://github.com/sherweb/OfficeProtect.Application/blob/master/docs/software/application-versioning.md>
[^usecases]: <https://wiki-sherweb.atlassian.net/wiki/spaces/TUR/pages/159023503/Product+-+All+Use+Cases>
